### PR TITLE
Reject requeue

### DIFF
--- a/queue_util/consumer.py
+++ b/queue_util/consumer.py
@@ -28,7 +28,7 @@ from queue_util import stats
 
 class Consumer(object):
 
-    def __init__(self, source_queue_name, handle_data, rabbitmq_host, serializer=None, compression=None, pause_delay=5, statsd_host=None, statsd_prefix="queue_util", workerid=None, worker_id=None, reject=False, requeue=False):
+    def __init__(self, source_queue_name, handle_data, rabbitmq_host, serializer=None, compression=None, pause_delay=5, statsd_host=None, statsd_prefix="queue_util", workerid=None, worker_id=None, reject=False, requeue=False, handle_exception=None):
         self.serializer = serializer
         self.compression = compression
         self.queue_cache = {}
@@ -49,6 +49,8 @@ class Consumer(object):
         # If both True, requeue takes priority
         self.requeue = requeue
         self.reject = reject
+
+        self.handle_exception = handle_exception
 
         if statsd_host:
             prefix = self.get_full_statsd_prefix(statsd_prefix, source_queue_name)
@@ -132,6 +134,9 @@ class Consumer(object):
                 # Keep going, but don't ack the message.
                 # Also, log the exception.
                 logging.exception("Exception handling data")
+
+                if self.handle_exception is not None:
+                    self.handle_exception()
 
                 if self.requeue:
                     message.requeue()

--- a/queue_util/consumer.py
+++ b/queue_util/consumer.py
@@ -28,7 +28,7 @@ from queue_util import stats
 
 class Consumer(object):
 
-    def __init__(self, source_queue_name, handle_data, rabbitmq_host, serializer=None, compression=None, pause_delay=5, statsd_host=None, statsd_prefix="queue_util", workerid=None, worker_id=None):
+    def __init__(self, source_queue_name, handle_data, rabbitmq_host, serializer=None, compression=None, pause_delay=5, statsd_host=None, statsd_prefix="queue_util", workerid=None, worker_id=None, reject=False, requeue=False):
         self.serializer = serializer
         self.compression = compression
         self.queue_cache = {}
@@ -45,6 +45,10 @@ class Consumer(object):
         self.handle_data = handle_data
 
         self.workerid = worker_id or workerid
+
+        # If both True, requeue takes priority
+        self.requeue = requeue
+        self.reject = reject
 
         if statsd_host:
             prefix = self.get_full_statsd_prefix(statsd_prefix, source_queue_name)
@@ -128,6 +132,11 @@ class Consumer(object):
                 # Keep going, but don't ack the message.
                 # Also, log the exception.
                 logging.exception("Exception handling data")
+
+                if self.requeue:
+                    message.requeue()
+                elif self.reject:
+                    message.reject()
 
                 stats.mark_failed_job(self.statsd_client)
 

--- a/queue_util/consumer.py
+++ b/queue_util/consumer.py
@@ -28,7 +28,7 @@ from queue_util import stats
 
 class Consumer(object):
 
-    def __init__(self, source_queue_name, handle_data, rabbitmq_host, serializer=None, compression=None, pause_delay=5, statsd_host=None, statsd_prefix="queue_util", workerid=None, worker_id=None, reject=False, requeue=False, handle_exception=None):
+    def __init__(self, source_queue_name, handle_data, rabbitmq_host, serializer=None, compression=None, pause_delay=5, statsd_host=None, statsd_prefix="queue_util", workerid=None, worker_id=None, dont_requeue=None, reject=None, handle_exception=None):
         self.serializer = serializer
         self.compression = compression
         self.queue_cache = {}
@@ -47,8 +47,8 @@ class Consumer(object):
         self.workerid = worker_id or workerid
 
         # If both True, requeue takes priority
-        self.requeue = requeue
-        self.reject = reject
+        self.requeue = False if dont_requeue else True
+        self.reject = True if reject else False
 
         self.handle_exception = handle_exception
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ REQUIREMENTS = [
 if __name__ == "__main__":
     setuptools.setup(
         name="queue_util",
-        version="0.0.5",
+        version="0.0.6",
         author="Sujay Mansingh",
         author_email="sujay.mansingh@gmail.com",
         packages=setuptools.find_packages(),


### PR DESCRIPTION
This adds the option to reject or requeue messages which fail/raise an exception. Without this no more messages will be ingested once the prefetch has run out (the .get call to kombu will simply block indefinitely).

Annoyingly RabbitMQ requeues the messages... at the end of the queue, so they come back right away (PITA in some cases).
